### PR TITLE
changed return to break in logic switch

### DIFF
--- a/virtual_input.cpp
+++ b/virtual_input.cpp
@@ -48,13 +48,13 @@ void VirtualInput::Update()
     {
     case BoolOperator::And:
         bResultSec1 = bResultSec0 && bResult2;
-        return;
+        break;
     case BoolOperator::Or:
         bResultSec1 = bResultSec0 || bResult2;
-        return;
+        break;
     case BoolOperator::Nor:
         bResultSec1 = !bResultSec0 || !bResult2;
-        return;
+        break;
     }
 
     nVal = input.Check(pConfig->eMode, false, bResultSec1);


### PR DESCRIPTION
This fixes an issue where having any variable configured in the third slot would cause a virtual input to always evaluate to false.